### PR TITLE
[Lourdes]: actualizacion de turnos funcionando con validaciones

### DIFF
--- a/backend/src/main/java/controllers/AppointmentController.java
+++ b/backend/src/main/java/controllers/AppointmentController.java
@@ -5,6 +5,7 @@ import services.impl.AppointmentServiceImp;
 import java.util.UUID;
 
 import dto.request.AppointmentDto;
+import dto.request.NewAppointmentDto;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -35,7 +36,7 @@ public class AppointmentController {
     @POST
     public Response createAppointment(AppointmentDto appointmentDto) throws Exception{
         appointmentService.createAppointment(appointmentDto);
-        return Response.status(Response.Status.CREATED).build();
+        return Response.status(Response.Status.OK).entity("Turno medico creado exitosamente").build();
         //lanzar excepcion si medico/usuario/horario no disponible/encontrado
     }
 
@@ -44,7 +45,20 @@ public class AppointmentController {
     //UUID como tipo de dato para id unicos en entidades JPA
     public Response deleteAppointment(@PathParam("id") UUID idUser, LocalTime consultingDate) throws Exception {
         appointmentService.deleteAppointment(idUser, consultingDate);
-        return Response.status(Response.Status.GONE).build();
+        return Response.status(Response.Status.OK).entity("Turno medico eliminado exitosamente").build();
+    }
+
+    @PUT
+    @Path("/{id}")
+    public Response updateAppointment(@PathParam("id") UUID idAppointment, NewAppointmentDto newAppointmentDto) throws Exception{
+        try {
+            appointmentService.updateAppointment(idAppointment, newAppointmentDto);
+            return Response.status(Response.Status.OK).entity("Turno médico actualizado exitosamente").build();
+        } catch (RuntimeException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error interno del servidor").build();
+        }
     }
 
 }

--- a/backend/src/main/java/controllers/SpecialistController.java
+++ b/backend/src/main/java/controllers/SpecialistController.java
@@ -1,0 +1,25 @@
+package controllers;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import services.impl.SpecialistServiceImp;
+
+@Path("/specialists")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+
+public class SpecialistController{
+
+    @Inject
+    private SpecialistServiceImp specialistServiceImp;
+
+    @GET
+    public Response getAllSpecialists(){
+        return Response.ok(specialistServiceImp.getAllSpecialists()).build();
+    }
+}

--- a/backend/src/main/java/dto/request/NewAppointmentDto.java
+++ b/backend/src/main/java/dto/request/NewAppointmentDto.java
@@ -1,0 +1,7 @@
+package dto.request;
+
+import java.time.LocalTime;
+import java.util.UUID;
+
+//nuevo dto para campos especificos obligatorios para una actualizacion del turno
+public record NewAppointmentDto(String consultingReason, LocalTime consultingDate, UUID medicalId) {}

--- a/backend/src/main/java/services/AppointmentService.java
+++ b/backend/src/main/java/services/AppointmentService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import models.Appointment;
 import java.util.UUID;
 import dto.request.AppointmentDto;
+import dto.request.NewAppointmentDto;
+
 import java.time.LocalTime;
 
 @Transactional
@@ -18,6 +20,8 @@ public interface AppointmentService {
     public void createAppointment(AppointmentDto appointmentDto) throws Exception;
 
     public void deleteAppointment(UUID idUser, LocalTime consultingDate);
+
+    public void updateAppointment(UUID idAppointment, NewAppointmentDto newAppointmentDto) throws Exception;
 
 }
 

--- a/backend/src/main/java/services/SpecialistService.java
+++ b/backend/src/main/java/services/SpecialistService.java
@@ -1,0 +1,12 @@
+package services;
+
+import java.util.List;
+
+import jakarta.transaction.Transactional;
+import models.enumerations.SpecialityType;
+import services.SpecialistService;
+
+@Transactional
+public interface SpecialistService {
+    public List<SpecialityType> getAllSpecialists();
+}

--- a/backend/src/main/java/services/impl/SpecialistServiceImp.java
+++ b/backend/src/main/java/services/impl/SpecialistServiceImp.java
@@ -1,0 +1,15 @@
+package services.impl;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import models.enumerations.SpecialityType;
+import services.SpecialistService;
+
+@ApplicationScoped
+public class SpecialistServiceImp implements SpecialistService {
+    @Override
+    public List<SpecialityType> getAllSpecialists() {
+        return List.of(SpecialityType.values());
+    }
+}


### PR DESCRIPTION
Actualizar turno médico:
permite a los usuarios actualizar la información de un turno médico existente identificado por su ID.
Se deberá enviar en el cuerpo de la solicitud los datos actualizados, que podrían incluir:
Nueva fecha y hora de la cita
ID del nuevo médico especialista
Nuevo motivo de la consulta